### PR TITLE
Fix the "ImportError: No module named botocore.exceptions" while the module installation

### DIFF
--- a/sceptre_s3_packager/__init__.py
+++ b/sceptre_s3_packager/__init__.py
@@ -1,7 +1,6 @@
 import logging
-from sceptre_s3_packager.s3_packager import KeyResolver, UploadHook  # noqa: F401, E501
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __author__ = 'Henrik Steen'
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     entry_points={
         'sceptre.hooks': [
-            'sceptre_s3_upload = sceptre_s3_packager:UploadHook',
+            'sceptre_s3_upload = sceptre_s3_packager.s3_packager:UploadHook',
         ],
         'sceptre.resolvers': [
-            'sceptre_s3_key = sceptre_s3_packager:KeyResolver',
+            'sceptre_s3_key = sceptre_s3_packager.s3_packager:KeyResolver',
         ]
     },
     classifiers=[


### PR DESCRIPTION
Hello. I've catch the module installation error related to a race condition when 'setup.py' opens the module file and falls as environment doesn't have the 'botocore' module installed yet (it is installing together with this module by the command $ pip install -r requirements.txt).

Could you remove those import to avoid this error as the 'botocore' module doesn't belong to installation requirements and we can just set a little bit longer internal module path within the 'entry_points' section.

Thank you.